### PR TITLE
Fixing highlight colours for neovim

### DIFF
--- a/autoload/diffchar.vim
+++ b/autoload/diffchar.vim
@@ -374,8 +374,8 @@ function! s:InitializeDiffChar(...)
 
 	" define a specific highlight group to show a position of a deleted
 	" unit, _DiffDelPos = DiffChange +/- bold/underline
-	let hm = has('gui_running') || (has('nvim') && &termguicolors)
-                    \? 'gui' : &t_Co > 1 ? 'cterm' : 'term'
+	let hm = has('gui_running') || (has('termguicolors') && &termguicolors)
+                \ ? 'gui' : &t_Co > 1 ? 'cterm' : 'term'
 	let hd = hlID(t:DChar.dhl.C)
 	let ha = map(['fg', 'bg', 'sp'], 'v:val . "=" . synIDattr(hd, v:val)')
 	let hx = filter(['bold', 'italic', 'reverse', 'inverse', 'standout',

--- a/autoload/diffchar.vim
+++ b/autoload/diffchar.vim
@@ -374,7 +374,8 @@ function! s:InitializeDiffChar(...)
 
 	" define a specific highlight group to show a position of a deleted
 	" unit, _DiffDelPos = DiffChange +/- bold/underline
-	let hm = has('gui_running') ? 'gui' : &t_Co > 1 ? 'cterm' : 'term'
+	let hm = has('gui_running') || (has('nvim') && &termguicolors)
+                    \? 'gui' : &t_Co > 1 ? 'cterm' : 'term'
 	let hd = hlID(t:DChar.dhl.C)
 	let ha = map(['fg', 'bg', 'sp'], 'v:val . "=" . synIDattr(hd, v:val)')
 	let hx = filter(['bold', 'italic', 'reverse', 'inverse', 'standout',


### PR DESCRIPTION
Dear Rick,

I am not sure if you are accepting pull requests for your plugin since I could not find any info on your plugin page.

I am using neovim with truecolors support so I had to do the following fix.
`if has('nvim') and termguicolor then use guicolors
`

Feel free of course to ignore it/alter it/do whatever you want.

Best wishes
Panagiotis