### PR TITLE
use cursor hl group for corresponding diff in terminal vim also

### DIFF
--- a/autoload/diffchar.vim
+++ b/autoload/diffchar.vim
@@ -75,7 +75,7 @@ function! s:SetDiffCharHL() abort
 	endif
 	" set DiffChar specific highlights
 	let s:DCharHL = {'A': 'DiffAdd', 'D': 'DiffDelete', 'n': 'LineNr',
-							\'c': (s:VF.GUIColors ? 'Cursor' : 'VertSplit')}
+							\'c': 'Cursor'}
 	for [fh, tn, th, ta] in [['DiffChange', 'C', 'dcDiffChange', ''],
 										\['DiffText', 'T', 'dcDiffText', ''],
 					\['DiffChange', 'E', 'dcDiffErase', 'bold,underline']] +


### PR DESCRIPTION
The documentations states:
`
While showing the exact differences, when the cursor is moved on a difference
unit, you can see its corresponding unit with |hl-Cursor| in another window,
based on a |g:DiffPairVisible|. If you change its default, the corresponding
unit is echoed in the command line or displayed in a popup/floating window
just below the cursor position or at the mouse position.
`
I am using terminal neovim, and after reading the documentation was changing Cursor highlight group to set the color of the corresponding difference, but it doesnt change anything. It seems that this is only the case if running GUI vim.

`	\'GUIColors': has('gui_running') ||
									\has('termguicolors') && &termguicolors,
`

If not, the hl group defaults to VertSplit hl group, but there is no mention of Vertsplit hl group in the documentation. It seems to me that the hl group should be Cursor regardless of whether gui vim is used.
